### PR TITLE
add initial list of Google Summer of Code Projects

### DIFF
--- a/project-ideas/google-soc/soc2018.md
+++ b/project-ideas/google-soc/soc2018.md
@@ -1,41 +1,41 @@
 ## Google Summer of Code 2018
 ### Project List
 
-**Project Name:** Team management module for MapCampaigner  
-**Project Description:** MapCampaigner is a field data collection organizing application. Organizers can define an area, define the features to collect, and recruit contributors. A missing component is an improved team management capabilities. This project would look to build out additional admin components for managing and engaging a team of contributors.  
-**Skills:** Python, Javascript, HTML/CSS  
-**Difficulty Level:** Medium  
-**Related readings/links:** 
+#### Team management module for MapCampaigner  
+- **Project Description:** MapCampaigner is a field data collection organizing application. Organizers can define an area, define the features to collect, and recruit contributors. A missing component is an improved team management capabilities. This project would look to build out additional admin components for managing and engaging a team of contributors.  
+- **Skills:** Python, Javascript, HTML/CSS  
+- **Difficulty Level:** Medium  
+- **Related readings/links:** 
   - Main repo: https://github.com/hotosm/field-campaigner
   - Live application: http://campaigns.hotosm.org/
-**Potential Mentors:** 
+- **Potential Mentors:** 
   - [Nate Smith](https://github.com/smit1678)
 
-**Project Name:** OpenAerialMap admin user account management  
-**Project Description:** OpenAerialMap added user accounts in the fall of 2017. One component that was not developed was admin functionalities - admin roles to edit user's profiles and manage a user's imagery. This project would focus on building out the necessary components to add this to the API and frontend.  
-**Skills:** Javascript/NodeJS, API basics  
-**Difficulty Level:** Medium
-**Related readings/links:** 
+#### OpenAerialMap admin user account management  
+- **Project Description:** OpenAerialMap added user accounts in the fall of 2017. One component that was not developed was admin functionalities - admin roles to edit user's profiles and manage a user's imagery. This project would focus on building out the necessary components to add this to the API and frontend.  
+- **Skills:** Javascript/NodeJS, API basics  
+- **Difficulty Level:** Medium
+- **Related readings/links:** 
   - Main repo: https://github.com/hotosm/oam-catalog
   - Blog post: https://blog.openaerialmap.org/new-in-oam-user-accounts-6ccd10449897
-**Potential Mentors:** 
+- **Potential Mentors:** 
   - [Sean Harkins](https://github.com/sharkinsspatial)
 
-**Project Name:** Visualize Change speed and frequency improvements  
-**Project Description:** Visualize Change is a time-based visualization rendering application that allows any user to define an area of interest and create a web-based visualization along with a mp4 video file for offline viewing. This project would focus on speed improvements to the processing and rendering, and working on the vector tile generation process to improve frequency of OSM data being generated.  
-**Skills:** NodeJS, Vector Tiles, API basics, OpenStreetmap knowledge  
-**Difficulty Level:** Difficult  
-**Related readings/links:** 
+#### Visualize Change speed and frequency improvements  
+- **Project Description:** Visualize Change is a time-based visualization rendering application that allows any user to define an area of interest and create a web-based visualization along with a mp4 video file for offline viewing. This project would focus on speed improvements to the processing and rendering, and working on the vector tile generation process to improve frequency of OSM data being generated.  
+- **Skills:** NodeJS, Vector Tiles, API basics, OpenStreetmap knowledge  
+- **Difficulty Level:** Difficult  
+- **Related readings/links:** 
   - Main repo: https://github.com/hotosm/visualize-change
-**Potential Mentors:** 
+- **Potential Mentors:** 
   - [Alyssa Wright](https://github.com/awright)
 
-**Project Name:** Machine learning module for Tasking Manager  
-**Project Description:** The Tasking Manager is HOT's primary application for coordinating and helping expose volunteers to map areas of the world in OpenStreetMap. Over the past year, we've been exploring how to integrate machine learning outputs into a Tasking Manager workflow. This project would focus on building the components to integrate a machine learning output into the Tasking Manager.  
-**Skills:** Python, Angular
-**Difficulty Level:** Medium
-**Related readings/links:** 
+#### Machine learning module for Tasking Manager  
+- **Project Description:** The Tasking Manager is HOT's primary application for coordinating and helping expose volunteers to map areas of the world in OpenStreetMap. Over the past year, we've been exploring how to integrate machine learning outputs into a Tasking Manager workflow. This project would focus on building the components to integrate a machine learning output into the Tasking Manager.  
+- **Skills:** Python, Angular
+- **Difficulty Level:** Medium
+- **Related readings/links:** 
   - https://github.com/hotosm/tasking-manager
   - https://developmentseed.org/blog/2017/09/15/power-mapping-with-machine-learning/
-**Potential Mentors:** 
+- **Potential Mentors:** 
   - [Nate Smith](https://github.com/smit1678)

--- a/project-ideas/google-soc/soc2018.md
+++ b/project-ideas/google-soc/soc2018.md
@@ -1,0 +1,41 @@
+## Google Summer of Code 2018
+### Project List
+
+**Project Name:** Team management module for MapCampaigner  
+**Project Description:** MapCampaigner is a field data collection organizing application. Organizers can define an area, define the features to collect, and recruit contributors. A missing component is an improved team management capabilities. This project would look to build out additional admin components for managing and engaging a team of contributors.  
+**Skills:** Python, Javascript, HTML/CSS  
+**Difficulty Level:** Medium  
+**Related readings/links:** 
+  - Main repo: https://github.com/hotosm/field-campaigner
+  - Live application: http://campaigns.hotosm.org/
+**Potential Mentors:** 
+  - [Nate Smith](https://github.com/smit1678)
+
+**Project Name:** OpenAerialMap admin user account management  
+**Project Description:** OpenAerialMap added user accounts in the fall of 2017. One component that was not developed was admin functionalities - admin roles to edit user's profiles and manage a user's imagery. This project would focus on building out the necessary components to add this to the API and frontend.  
+**Skills:** Javascript/NodeJS, API basics  
+**Difficulty Level:** Medium
+**Related readings/links:** 
+  - Main repo: https://github.com/hotosm/oam-catalog
+  - Blog post: https://blog.openaerialmap.org/new-in-oam-user-accounts-6ccd10449897
+**Potential Mentors:** 
+  - [Sean Harkins](https://github.com/sharkinsspatial)
+
+**Project Name:** Visualize Change speed and frequency improvements  
+**Project Description:** Visualize Change is a time-based visualization rendering application that allows any user to define an area of interest and create a web-based visualization along with a mp4 video file for offline viewing. This project would focus on speed improvements to the processing and rendering, and working on the vector tile generation process to improve frequency of OSM data being generated.  
+**Skills:** NodeJS, Vector Tiles, API basics, OpenStreetmap knowledge  
+**Difficulty Level:** Difficult  
+**Related readings/links:** 
+  - Main repo: https://github.com/hotosm/visualize-change
+**Potential Mentors:** 
+  - [Alyssa Wright](https://github.com/awright)
+
+**Project Name:** Machine learning module for Tasking Manager  
+**Project Description:** The Tasking Manager is HOT's primary application for coordinating and helping expose volunteers to map areas of the world in OpenStreetMap. Over the past year, we've been exploring how to integrate machine learning outputs into a Tasking Manager workflow. This project would focus on building the components to integrate a machine learning output into the Tasking Manager.  
+**Skills:** Python, Angular
+**Difficulty Level:** Medium
+**Related readings/links:** 
+  - https://github.com/hotosm/tasking-manager
+  - https://developmentseed.org/blog/2017/09/15/power-mapping-with-machine-learning/
+**Potential Mentors:** 
+  - [Nate Smith](https://github.com/smit1678)

--- a/project-ideas/google-soc/soc2018.md
+++ b/project-ideas/google-soc/soc2018.md
@@ -1,5 +1,4 @@
-## Google Summer of Code 2018
-### Project List
+## Google Summer of Code 2018 Project List
 
 #### Team management module for MapCampaigner  
 - **Project Description:** MapCampaigner is a field data collection organizing application. Organizers can define an area, define the features to collect, and recruit contributors. A missing component is an improved team management capabilities. This project would look to build out additional admin components for managing and engaging a team of contributors.  


### PR DESCRIPTION
This PR adds a very initial list of potential Google Summer of Code projects. Purpose is to get an initial list up ahead of the required deadline. We can add others or hone in on these further over the next few weeks before students evaluate in March. 

To do the discussions, make a ticket to open a discussion on an idea. 